### PR TITLE
feat: model switching, Ctrl+C exit, and debug overlay

### DIFF
--- a/internal/api/tracker.go
+++ b/internal/api/tracker.go
@@ -9,7 +9,13 @@ var modelPricing = map[string][2]float64{
 	"gpt-5.1-codex-mini": {1.50, 6.00},   // {input, output}
 	"gpt-5.1-codex":      {3.00, 12.00},
 	"o3-pro":             {20.00, 80.00},
+	"gpt-5.4":            {2.50, 10.00},
+	"gpt-5.3-codex":      {3.00, 12.00},
+	"o4-mini":             {1.10, 4.40},
 }
+
+// CycleModels defines the models available for quick-switching via Ctrl+/.
+var CycleModels = []string{"gpt-5.4", "gpt-5.3-codex", "o4-mini"}
 
 // Tracker accumulates token counts and cost across a session.
 type Tracker struct {
@@ -55,6 +61,12 @@ func (t *Tracker) Cost() float64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.cost
+}
+
+func (t *Tracker) Model() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.model
 }
 
 func (t *Tracker) SetModel(model string) {

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -53,8 +53,11 @@ func (r *Registry) Connect(ctx context.Context, name string) error {
 
 	tools, err := client.ListTools(ctx)
 	if err != nil {
-		client.Close()
-		return fmt.Errorf("list tools for %s: %w", name, err)
+		// ListTools failure is non-fatal — server connected but may not
+		// support tools/list yet (e.g. older protocol versions).
+		// Keep the client connected with an empty tool list.
+		fmt.Printf("Warning: MCP server %s connected but tools/list failed: %v\n", name, err)
+		tools = nil
 	}
 
 	r.clients[name] = client

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/robinojw/dj/config"
 	"github.com/robinojw/dj/internal/api"
 	"github.com/robinojw/dj/internal/checkpoint"
@@ -47,6 +48,8 @@ type App struct {
 	permRequestCh   chan modes.PermissionRequest
 	checkpoints     *checkpoint.Manager
 	hooks           *hooks.Runner
+	debugOverlay    components.DebugOverlay
+	debugMode       bool
 	width           int
 	height          int
 }
@@ -65,7 +68,7 @@ func NewApp(
 		cfg.Execution.Deny.Tools,
 	)
 
-	return App{
+	app := App{
 		screen:          ScreenChat,
 		chat:            screens.NewChatModel(t),
 		team:            screens.NewTeamModel(t),
@@ -82,7 +85,10 @@ func NewApp(
 		turboModal:      components.NewTurboModal(t),
 		permRequestCh:   make(chan modes.PermissionRequest, 10),
 		checkpoints:     checkpoint.NewManager(20),
+		debugOverlay:    components.NewDebugOverlay(t),
 	}
+	app.chat.SetModel(model)
+	return app
 }
 
 func (a App) Init() tea.Cmd {
@@ -94,10 +100,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+		a.debugOverlay.SetSize(msg.Width, msg.Height)
 
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+q":
+		case "ctrl+c", "ctrl+q":
 			return a, tea.Quit
 		case "ctrl+e":
 			if a.screen != ScreenEnhance {
@@ -115,6 +122,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.screen != ScreenTeam {
 				return a, a.pushScreen(ScreenTeam)
 			}
+		case "ctrl+/":
+			a.cycleModel()
+			return a, nil
+		case "ctrl+d":
+			a.debugMode = !a.debugMode
+			a.debugOverlay.Toggle()
+			return a, nil
 		case "tab":
 			// Cycle: Confirm → Plan → Turbo → Confirm
 			newMode := (a.mode + 1) % 3
@@ -163,6 +177,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screens.TeamSpawnedMsg:
 		return a, a.pushScreen(ScreenTeam)
 
+	case screens.StreamErrorMsg:
+		if a.debugMode {
+			a.debugOverlay.AddError(msg.Err.Error())
+		}
+
 	case modes.PermissionRequest:
 		var cmd tea.Cmd
 		a.permissionModal, cmd = a.permissionModal.Update(msg)
@@ -188,18 +207,34 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (a App) View() string {
+	var base string
 	switch a.screen {
 	case ScreenTeam:
-		return a.team.View()
+		base = a.team.View()
 	case ScreenEnhance:
-		return a.enhance.View()
+		base = a.enhance.View()
 	case ScreenMCP:
-		return a.mcpManager.View()
+		base = a.mcpManager.View()
 	case ScreenSkills:
-		return a.skillBrowser.View()
+		base = a.skillBrowser.View()
 	default:
-		return a.chat.View()
+		base = a.chat.View()
 	}
+
+	if a.debugMode {
+		overlay := a.debugOverlay.View()
+		if overlay != "" {
+			// Place the debug panel in the top-right, overlaid on the base
+			return lipgloss.Place(a.width, a.height,
+				lipgloss.Right, lipgloss.Top,
+				overlay,
+				lipgloss.WithWhitespaceChars(" "),
+				lipgloss.WithWhitespaceForeground(lipgloss.NoColor{}),
+			) + "\n" + base
+		}
+	}
+
+	return base
 }
 
 func (a *App) pushScreen(s Screen) tea.Cmd {
@@ -216,6 +251,25 @@ func (a *App) popScreen() tea.Cmd {
 	a.screen = a.screenStack[len(a.screenStack)-1]
 	a.screenStack = a.screenStack[:len(a.screenStack)-1]
 	return nil
+}
+
+func (a *App) cycleModel() {
+	models := api.CycleModels
+	current := -1
+	for i, m := range models {
+		if m == a.model {
+			current = i
+			break
+		}
+	}
+	next := models[(current+1)%len(models)]
+	a.model = next
+	a.tracker.SetModel(next)
+	a.chat.SetModel(next)
+
+	if a.debugMode {
+		a.debugOverlay.AddInfo("Model switched to " + next)
+	}
 }
 
 func (a *App) handleSubmit(text string) tea.Cmd {

--- a/internal/tui/components/debug_overlay.go
+++ b/internal/tui/components/debug_overlay.go
@@ -1,0 +1,149 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/robinojw/dj/internal/tui/theme"
+)
+
+const maxDebugEntries = 50
+
+// DebugEntry represents a single debug log entry.
+type DebugEntry struct {
+	Time    time.Time
+	Level   string // "ERROR", "WARN", "INFO"
+	Message string
+}
+
+// DebugOverlay displays error and debug messages in a floating panel.
+type DebugOverlay struct {
+	entries []DebugEntry
+	visible bool
+	width   int
+	height  int
+	theme   *theme.Theme
+}
+
+func NewDebugOverlay(t *theme.Theme) DebugOverlay {
+	return DebugOverlay{theme: t}
+}
+
+func (d *DebugOverlay) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+}
+
+func (d *DebugOverlay) Toggle() {
+	d.visible = !d.visible
+}
+
+func (d *DebugOverlay) IsVisible() bool {
+	return d.visible
+}
+
+func (d *DebugOverlay) AddError(msg string) {
+	d.add("ERROR", msg)
+}
+
+func (d *DebugOverlay) AddWarn(msg string) {
+	d.add("WARN", msg)
+}
+
+func (d *DebugOverlay) AddInfo(msg string) {
+	d.add("INFO", msg)
+}
+
+func (d *DebugOverlay) add(level, msg string) {
+	d.entries = append(d.entries, DebugEntry{
+		Time:    time.Now(),
+		Level:   level,
+		Message: msg,
+	})
+	if len(d.entries) > maxDebugEntries {
+		d.entries = d.entries[len(d.entries)-maxDebugEntries:]
+	}
+}
+
+func (d *DebugOverlay) Clear() {
+	d.entries = nil
+}
+
+func (d DebugOverlay) View() string {
+	if !d.visible || d.width == 0 || d.height == 0 {
+		return ""
+	}
+
+	panelW := d.width / 3
+	if panelW < 30 {
+		panelW = 30
+	}
+	panelH := d.height / 3
+	if panelH < 5 {
+		panelH = 5
+	}
+
+	// Build log lines (most recent at bottom)
+	maxLines := panelH - 3 // border + title + padding
+	if maxLines < 1 {
+		maxLines = 1
+	}
+	start := 0
+	if len(d.entries) > maxLines {
+		start = len(d.entries) - maxLines
+	}
+
+	var lines []string
+	for _, e := range d.entries[start:] {
+		ts := e.Time.Format("15:04:05")
+		var levelStyle lipgloss.Style
+		switch e.Level {
+		case "ERROR":
+			levelStyle = d.theme.ErrorStyle()
+		case "WARN":
+			levelStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(d.theme.Colors.Warning)).
+				Bold(true)
+		default:
+			levelStyle = d.theme.MutedStyle()
+		}
+		line := fmt.Sprintf("%s %s %s",
+			d.theme.MutedStyle().Render(ts),
+			levelStyle.Render(e.Level),
+			e.Message,
+		)
+		// Truncate to fit panel width
+		if lipgloss.Width(line) > panelW-4 {
+			line = line[:panelW-7] + "..."
+		}
+		lines = append(lines, line)
+	}
+
+	if len(lines) == 0 {
+		lines = append(lines, d.theme.MutedStyle().Render("No debug messages"))
+	}
+
+	content := strings.Join(lines, "\n")
+
+	panel := lipgloss.NewStyle().
+		Width(panelW).
+		Height(panelH).
+		Background(lipgloss.Color(d.theme.Colors.PanelBg)).
+		Foreground(lipgloss.Color(d.theme.Colors.Foreground)).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(d.theme.Colors.Error)).
+		Padding(0, 1).
+		Render(d.theme.ErrorStyle().Render("DEBUG") + "\n" + content)
+
+	// Position top-right
+	leftPad := d.width - lipgloss.Width(panel)
+	if leftPad < 0 {
+		leftPad = 0
+	}
+
+	return lipgloss.NewStyle().
+		PaddingLeft(leftPad).
+		Render(panel)
+}

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -17,6 +17,7 @@ type StatusBar struct {
 	CumulativeCost float64
 	ActiveMCPs     []string
 	Mode           modes.ExecutionMode
+	Model          string // active model name
 	LSPServer      string // e.g. "gopls"
 	Compacting     bool
 	Width          int
@@ -46,6 +47,11 @@ func (s StatusBar) View() string {
 	modeStyle := s.getModeStyle()
 	modeBadge := modeStyle.Render(s.Mode.StatusLabel()) + "  "
 
+	var modelBadge string
+	if s.Model != "" {
+		modelBadge = s.Theme.BadgeStyle().Render(s.Model) + "  "
+	}
+
 	var lspBadge string
 	if s.LSPServer != "" {
 		lspBadge = " " + s.Theme.BadgeStyle().Render("LSP: "+s.LSPServer)
@@ -56,8 +62,9 @@ func (s StatusBar) View() string {
 		compactBadge = " " + s.Theme.AccentStyle().Render("Compacting context...")
 	}
 
-	content := fmt.Sprintf("%sCTX %s %.1f%%  OUT %s  $%.4f%s%s%s",
+	content := fmt.Sprintf("%s%sCTX %s %.1f%%  OUT %s  $%.4f%s%s%s",
 		modeBadge,
+		modelBadge,
 		ctxBar, ctxPct,
 		humanize.Comma(int64(s.OutputTokens)),
 		s.CumulativeCost,

--- a/internal/tui/screens/chat.go
+++ b/internal/tui/screens/chat.go
@@ -194,3 +194,7 @@ func (m *ChatModel) SetMode(mode agents.AgentMode) {
 	m.Mode = mode
 	m.statusBar.Mode = mode
 }
+
+func (m *ChatModel) SetModel(model string) {
+	m.statusBar.Model = model
+}


### PR DESCRIPTION
## Summary
- **Model switching (Ctrl+/)**: Cycles between gpt-5.4, gpt-5.3-codex, and o4-mini. Active model displayed as a badge in the status bar.
- **Ctrl+C to exit**: Now exits the TUI alongside existing Ctrl+Q.
- **Debug overlay (Ctrl+D)**: Toggleable overlay in the top-right showing timestamped ERROR/WARN/INFO entries. Stream errors and model switches are automatically logged.
- **MCP startup fix**: `tools/list` failures are now non-fatal — servers stay connected with an empty tool list instead of being disconnected.

## Test plan
- [ ] Verify Ctrl+/ cycles through gpt-5.4 → gpt-5.3-codex → o4-mini → gpt-5.4 and status bar updates
- [ ] Verify Ctrl+C exits the TUI cleanly
- [ ] Verify Ctrl+D toggles the debug overlay in the top-right corner
- [ ] Verify stream errors appear in the debug overlay when debug mode is active
- [ ] Verify MCP servers with unsupported tools/list no longer cause startup failures
- [ ] Verify all existing tests pass (`go test ./...`)