### PR TITLE
docs: improve Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,15 @@ Themes support custom JSON overrides.
 
 ### Homebrew (Recommended)
 
+**Option 1 - Direct install:**
 ```bash
 brew install robinojw/dj/dj
+```
+
+**Option 2 - Tap then install:**
+```bash
+brew tap robinojw/dj
+brew install dj
 ```
 
 ### Go Install


### PR DESCRIPTION
## Summary

Improves the Homebrew installation section by documenting both valid installation methods:

**Option 1 - Direct install:**
```bash
brew install robinojw/dj/dj
```

**Option 2 - Tap then install:**
```bash
brew tap robinojw/dj
brew install dj
```

## Context

After investigating why `brew install robinojw/dj` doesn't work (it's not a valid Homebrew pattern, we found that users have two valid options. This PR documents both approaches so users can choose their preferred method.

Option 2 is particularly nice for users who prefer the cleaner  command after tapping the repository once.

## Changes

- Updated README.md Homebrew installation section to show both options
- Added clear labels for each approach
EOF
)