### PR TITLE
fix: repair Tab mode switching and Ctrl+/ model cycling

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -109,6 +109,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.debugOverlay.SetSize(msg.Width, msg.Height)
 
 	case tea.KeyMsg:
+		// Route key events to turbo modal when visible
+		if a.turboModal.Visible() {
+			a.turboModal = a.turboModal.HandleKey(msg)
+			if !a.turboModal.Visible() {
+				if a.turboModal.Confirmed() {
+					a.turboConfirmed = true
+					a.mode = modes.ModeTurbo
+					a.gate.SetMode(modes.ModeTurbo)
+					a.chat.SetMode(modes.ModeTurbo)
+				}
+			}
+			return a, nil
+		}
+
 		switch msg.String() {
 		case "ctrl+c", "ctrl+q":
 			return a, tea.Quit
@@ -128,7 +142,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.screen != ScreenTeam {
 				return a, a.pushScreen(ScreenTeam)
 			}
-		case "ctrl+/":
+		case "ctrl+_":
 			a.cycleModel()
 			return a, nil
 		case "ctrl+d":
@@ -142,18 +156,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Check if switching to Turbo
 			if newMode == modes.ModeTurbo && !a.turboConfirmed {
 				a.turboModal.Show()
-				respCh := make(chan bool, 1)
-				a.turboModal.SetResponseChannel(respCh)
-
-				go func() {
-					confirmed := <-respCh
-					if confirmed {
-						a.turboConfirmed = true
-						a.mode = modes.ModeTurbo
-						a.gate.SetMode(modes.ModeTurbo)
-						a.chat.SetMode(modes.ModeTurbo)
-					}
-				}()
 				return a, nil
 			}
 
@@ -263,6 +265,14 @@ func (a App) View() string {
 		base = a.skillBrowser.View()
 	default:
 		base = a.chat.View()
+	}
+
+	// Overlay modals when visible
+	if a.turboModal.Visible() {
+		base = lipgloss.JoinVertical(lipgloss.Left, a.turboModal.View(), base)
+	}
+	if a.permissionModal.Visible() {
+		base = lipgloss.JoinVertical(lipgloss.Left, a.permissionModal.View(), base)
 	}
 
 	if a.debugMode {

--- a/internal/tui/components/turbo_modal.go
+++ b/internal/tui/components/turbo_modal.go
@@ -9,9 +9,9 @@ import (
 )
 
 type TurboModal struct {
-	visible bool
-	respCh  chan bool
-	theme   *theme.Theme
+	visible   bool
+	confirmed bool
+	theme     *theme.Theme
 }
 
 func NewTurboModal(t *theme.Theme) TurboModal {
@@ -22,14 +22,33 @@ func NewTurboModal(t *theme.Theme) TurboModal {
 
 func (m *TurboModal) Show() {
 	m.visible = true
+	m.confirmed = false
 }
 
 func (m TurboModal) Visible() bool {
 	return m.visible
 }
 
-func (m *TurboModal) SetResponseChannel(ch chan bool) {
-	m.respCh = ch
+func (m TurboModal) Confirmed() bool {
+	return m.confirmed
+}
+
+// HandleKey processes a key event and returns the updated modal.
+func (m TurboModal) HandleKey(msg tea.KeyMsg) TurboModal {
+	if !m.visible {
+		return m
+	}
+
+	switch msg.String() {
+	case "y":
+		m.confirmed = true
+		m.visible = false
+	case "n", "esc":
+		m.confirmed = false
+		m.visible = false
+	}
+
+	return m
 }
 
 func (m TurboModal) Update(msg tea.Msg) (TurboModal, tea.Cmd) {
@@ -39,21 +58,8 @@ func (m TurboModal) Update(msg tea.Msg) (TurboModal, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "y":
-			if m.respCh != nil {
-				m.respCh <- true
-			}
-			m.visible = false
-			return m, nil
-
-		case "n", "esc":
-			if m.respCh != nil {
-				m.respCh <- false
-			}
-			m.visible = false
-			return m, nil
-		}
+		m = m.HandleKey(msg)
+		return m, nil
 	}
 
 	return m, nil

--- a/internal/tui/components/turbo_modal_test.go
+++ b/internal/tui/components/turbo_modal_test.go
@@ -25,23 +25,14 @@ func TestTurboModal_Confirm(t *testing.T) {
 	modal := NewTurboModal(theme.DefaultTheme())
 	modal.Show()
 
-	respCh := make(chan bool, 1)
-	modal.SetResponseChannel(respCh)
-
 	// Press 'y' to confirm
 	modal, _ = modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 
-	select {
-	case confirmed := <-respCh:
-		if !confirmed {
-			t.Error("Expected confirmation")
-		}
-	default:
-		t.Error("No response received")
-	}
-
 	if modal.Visible() {
 		t.Error("Modal should be hidden after confirmation")
+	}
+	if !modal.Confirmed() {
+		t.Error("Expected confirmation")
 	}
 }
 
@@ -49,22 +40,13 @@ func TestTurboModal_Cancel(t *testing.T) {
 	modal := NewTurboModal(theme.DefaultTheme())
 	modal.Show()
 
-	respCh := make(chan bool, 1)
-	modal.SetResponseChannel(respCh)
-
 	// Press 'n' to cancel
 	modal, _ = modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 
-	select {
-	case confirmed := <-respCh:
-		if confirmed {
-			t.Error("Expected cancellation")
-		}
-	default:
-		t.Error("No response received")
-	}
-
 	if modal.Visible() {
 		t.Error("Modal should be hidden after cancellation")
+	}
+	if modal.Confirmed() {
+		t.Error("Expected cancellation")
 	}
 }


### PR DESCRIPTION
## Summary

- **Ctrl+/ model cycling**: Terminals send byte `0x1F` for Ctrl+/, which Bubble Tea maps to `"ctrl+_"`, not `"ctrl+/"`. The binding never matched. Fixed by changing the key string to `"ctrl+_"`.
- **Tab mode switching**: Got stuck after the first press (Confirm -> Plan) because subsequent presses always tried Plan -> Turbo, which triggered a Turbo confirmation modal that could never complete — the modal used a goroutine+channel pattern incompatible with Bubble Tea's Elm architecture (never received key events, never rendered). Replaced with direct state tracking (`HandleKey`/`Confirmed`), added key routing to the modal when visible, and rendered the modal overlay in `App.View`.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Run the app, press Tab — mode cycles through Confirm -> Plan -> Turbo (with confirmation prompt) -> Confirm
- [ ] Run the app, press Ctrl+/ — model cycles through the configured models
- [ ] Turbo confirmation modal renders and responds to Y/N/Esc